### PR TITLE
Restore RGB color after reboot

### DIFF
--- a/Peg/Firmware/main.py
+++ b/Peg/Firmware/main.py
@@ -16,9 +16,25 @@ from kmk.extensions.media_keys import MediaKeys
 from kmk.handlers.sequences import simple_key_sequence
 from kmk.modules.encoder import EncoderHandler
 from kmk.extensions.RGB import RGB
-rgb = RGB(pixel_pin=keyboard.rgb_pixel_pin, num_pixels=keyboard.rgb_num_pixel, hue_default=80)
+import microcontroller
+
+rgb = RGB(
+    pixel_pin=keyboard.rgb_pixel_pin, 
+    num_pixels=keyboard.rgb_num_pixel, 
+    hue_default=microcontroller.nvm[0]
+)
+
+def on_move_do(state):
+    if state is not None and state['direction'] == -1:
+        rgb.decrease_hue()
+    else:
+        rgb.increase_hue()
+    microcontroller.nvm[0] = rgb.hue
+
 encoder_handler = EncoderHandler()
 encoder_handler.pins = ((keyboard.rgb_encoder_a, keyboard.rgb_encoder_b, None, False),)
+encoder_handler.on_move_do = lambda x, y, state: on_move_do(state)
+
 encoder_handler.map =   [ ((KC.RGB_HUD, KC.RGB_HUI, KC.RGB_TOG),), ]
 keyboard.extensions.append(MediaKeys())
 keyboard.extensions.append(rgb)


### PR DESCRIPTION
This is a small change that uses the microcontroller's non-volatile storage to store the current RGB value after it was changed using the encoder knob and then restores the latest value when the board is booting up. Before this change the RGB color always defaulted back to hue 80 (green) after rebooting. On first boot the RGB color is random, depending on the value that is present in `microcontroller.nvm[0]`.

The code makes use of the `on_move_do` callback of the encoder to 
- Increase/decrease the hue
- Store the new hue value to `microcontroller.nvm[0]`

For some reason `encoder_handler.pins` still needs to be defined although they do not have any effect. Without this the `on_move_do` callback isn't called.

Demo: https://youtube.com/shorts/jpdKRQX62fE
Build/Dev Stream :D https://youtu.be/tzxYnoqEcDo?list=PL1fjlNqlUKnU5sWprahnJyDtUcoqpDaWt&t=4111